### PR TITLE
[ace] Add support for uwp (#11441)

### DIFF
--- a/ports/ace/CONTROL
+++ b/ports/ace/CONTROL
@@ -1,8 +1,7 @@
 Source: ace
-Version: 6.5.9-1
+Version: 6.5.9-2
 Homepage: https://www.dre.vanderbilt.edu/~schmidt/ACE.html
 Description: The ADAPTIVE Communication Environment
-Supports: !uwp
 
 Feature: wchar
 Description: Enable extra wide char functions in ACE

--- a/ports/ace/portfile.cmake
+++ b/ports/ace/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(ON_TARGET "uwp")
-
 # Using zip archive under Linux would cause sh/perl to report "No such file or directory" or "bad interpreter"
 # when invoking `prj_install.pl`.
 # So far this issue haven't yet be triggered under WSL 1 distributions. Not sure the root cause of it.
@@ -100,9 +98,13 @@ elseif(VCPKG_TARGET_IS_OSX)
   file(WRITE ${ACE_ROOT}/include/makeinclude/platform_macros.GNU "include $(ACE_ROOT)/include/makeinclude/platform_macosx.GNU")
 endif()
 
+if(VCPKG_TARGET_IS_UWP)
+  set(MPC_VALUE_TEMPLATE -value_template link_options+=/APPCONTAINER)
+endif()
+
 # Invoke mwc.pl to generate the necessary solution and project files
 vcpkg_execute_build_process(
-    COMMAND ${PERL} ${ACE_ROOT}/bin/mwc.pl -type ${SOLUTION_TYPE} -features "${ACE_FEATURES}" ace ${MPC_STATIC_FLAG}
+    COMMAND ${PERL} ${ACE_ROOT}/bin/mwc.pl -type ${SOLUTION_TYPE} -features "${ACE_FEATURES}" ace ${MPC_STATIC_FLAG} ${MPC_VALUE_TEMPLATE}
     WORKING_DIRECTORY ${ACE_ROOT}
     LOGNAME mwc-${TARGET_TRIPLET}
 )
@@ -174,9 +176,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
   install_ace_library(${ACE_ROOT} "ACE_ETCL")
   install_ace_library(${ACE_ROOT} "ACE_ETCL_Parser")
   install_ace_library(${ACE_ROOT} "ACE_Monitor_Control")
-  if(NOT VCPKG_CMAKE_SYSTEM_NAME)
-    install_ace_library(${ACE_ROOT} "ACE_QoS")
-  endif()
+  install_ace_library(${ACE_ROOT} "ACE_QoS")
   install_ace_library(${ACE_ROOT} "ACE_RLECompression")
   if("ssl" IN_LIST FEATURES)
       install_ace_library(${ACE_ROOT} "ACE_SSL")
@@ -185,8 +185,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
   vcpkg_copy_pdbs()
 
   # Handle copyright
-  file(COPY ${ACE_ROOT}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/ace)
-  file(RENAME ${CURRENT_PACKAGES_DIR}/share/ace/COPYING ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)
+  file(INSTALL ${ACE_ROOT}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 elseif(VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)
   FIND_PROGRAM(MAKE make)
   IF (NOT MAKE)

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -45,8 +45,6 @@
 7zip:x64-osx=fail
 7zip:x64-uwp=fail
 abseil:arm-uwp=fail
-ace:arm-uwp=fail
-ace:x64-uwp=fail
 activemq-cpp:x64-windows-static=fail
 activemq-cpp:x64-linux=fail
 activemq-cpp:x64-osx=fail


### PR DESCRIPTION
* [ace] Update to 6.5.8

* Address review comments

    * ports/ace/portfile.cmake:

* Put back copy step

    * ports/ace/portfile.cmake:

* Fixed error

    * ports/ace/portfile.cmake:

* ARM should work, let us try it

    * ports/ace/portfile.cmake:

* ARM doesn't work yet, so disable it again
    * ports/ace/portfile.cmake:

* Add support for vcpkg of ace on MacOSX

    * ports/ace/portfile.cmake:

* [ace] Add patch to fix Visual Studio 2019 internal compiler error

    * ports/ace/process_manager.patch:
      Added.

    * ports/ace/CONTROL:
    * ports/ace/portfile.cmake:

* Attempt to fix apply patches

    * ports/ace/portfile.cmake:

* [ace] Updated baseline for ace, 4 configurations work again with the applied patch

    * scripts/ci.baseline.txt:

* Address review comments

    * ports/ace/portfile.cmake:

* Revised patch for ACE

    * ports/ace/process_manager.patch:

* [ace] Add support for uwp

    * ports/ace/portfile.cmake:

* ace now works in all configurations

    * scripts/ci.baseline.txt:

* Removed !uwp and update version

    * ports/ace/CONTROL:

* Simplified install of copyright file and on windows we always have a QoS library

    * ports/ace/portfile.cmake:

**Describe the pull request**

- What does your PR fix? Fixes #

- Which triplets are supported/not supported? Have you updated the CI baseline?

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
