### PR TITLE
[clapack] Ignore check of lapack:x64-osx in the baseline (#13148)

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -208,6 +208,7 @@ civetweb:arm-uwp            = skip
 civetweb:x64-uwp            = skip
 # clapack is replaced by lapack-reference. 
 clapack:x64-linux = skip
+clapack:x64-osx = skip
 clapack:x64-windows = skip
 clapack:x64-windows-static = skip
 clapack:x86-windows = skip


### PR DESCRIPTION
Merge from microsoft/vcpkg