### PR TITLE
[azure-security-keyvault-*] Add new ports (#17143)

### DIFF
--- a/ports/azure-security-keyvault-common-cpp/portfile.cmake
+++ b/ports/azure-security-keyvault-common-cpp/portfile.cmake
@@ -1,0 +1,19 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Azure/azure-sdk-for-cpp
+    REF azure-security-keyvault-common_4.0.0-beta.1
+    SHA512 7364bf775bbf6115bf54ee0c2df8b2bae35ea31c669fcbc358edd00a948f2c73926fbf88282ff5442f40ead9cdfc78661a08e4f86002ac2eac5e78ddd13eb33d
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-common/
+    PREFER_NINJA
+    OPTIONS
+        -DWARNINGS_AS_ERRORS=OFF
+)
+
+vcpkg_install_cmake()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_fixup_cmake_targets()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+vcpkg_copy_pdbs()

--- a/ports/azure-security-keyvault-common-cpp/vcpkg.json
+++ b/ports/azure-security-keyvault-common-cpp/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "azure-security-keyvault-common-cpp",
+  "version-string": "4.0.0-beta.1",
+  "description": [
+    "Microsoft Azure Common Key Vault SDK for C++",
+    "This library provides common Azure KeyVault-related abstractions for Azure SDK."
+  ],
+  "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/master/sdk/keyvault/azure-security-keyvault-common",
+  "dependencies": [
+    "azure-core-cpp"
+  ]
+}

--- a/ports/azure-security-keyvault-keys-cpp/portfile.cmake
+++ b/ports/azure-security-keyvault-keys-cpp/portfile.cmake
@@ -1,0 +1,19 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Azure/azure-sdk-for-cpp
+    REF azure-security-keyvault-keys_4.0.0-beta.1
+    SHA512 fb5158320c859f27c97c86908fd4c3f7ceec2ec8b0ca3c213a075992b62dfdefa3a560173bc7034153c273c30abd7fd0a84f98842810de2f78412549e5d34ee4
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-keys/
+    PREFER_NINJA
+    OPTIONS
+        -DWARNINGS_AS_ERRORS=OFF
+)
+
+vcpkg_install_cmake()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_fixup_cmake_targets()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+vcpkg_copy_pdbs()

--- a/ports/azure-security-keyvault-keys-cpp/vcpkg.json
+++ b/ports/azure-security-keyvault-keys-cpp/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "azure-security-keyvault-keys-cpp",
+  "version-string": "4.0.0-beta.1",
+  "description": [
+    "Microsoft Azure Key Vault Keys SDK for C++",
+    "This library provides Azure Key Vault Keys SDK."
+  ],
+  "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/master/sdk/keyvault/azure-security-keyvault-keys",
+  "dependencies": [
+    "azure-security-keyvault-common-cpp"
+  ]
+}

--- a/versions/a-/azure-security-keyvault-common-cpp.json
+++ b/versions/a-/azure-security-keyvault-common-cpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c084ea582625d5235560b84953af1240270c5a18",
+      "version-string": "4.0.0-beta.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/a-/azure-security-keyvault-keys-cpp.json
+++ b/versions/a-/azure-security-keyvault-keys-cpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "816b5bddbbd2e2396336120039220dd7c83a898d",
+      "version-string": "4.0.0-beta.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -264,6 +264,14 @@
       "baseline": "2020-06-17",
       "port-version": 2
     },
+    "azure-security-keyvault-common-cpp": {
+      "baseline": "4.0.0-beta.1",
+      "port-version": 0
+    },
+    "azure-security-keyvault-keys-cpp": {
+      "baseline": "4.0.0-beta.1",
+      "port-version": 0
+    },
     "azure-storage-blobs-cpp": {
       "baseline": "12.0.0-beta.10",
       "port-version": 0


### PR DESCRIPTION
* [azure-core-cpp] Update to 1.0.0-beta.8
## 1.0.0-beta.8 (2021-04-07)

### New Features

- Added `Azure::Core::Url::GetScheme()`.
- Added `Azure::Core::Context::TryGetValue()`.
- Added `Azure::Core::Context::GetDeadline()`.
- Added `Azure::Core::Credentials::TokenCredentialOptions`.
- Added useful fields to the `Azure::Core::RequestFailedException` class such as `StatusCode`, `ReasonPhrase`, and the `RawResponse`, for better diagnosis of errors.

### Breaking Changes

- Simplified the `Response<T>` API surface to expose two public fields with direct access: `T Value` and a `unique_ptr` to an `Azure::Core::Http::RawResponse`.
- Renamed `Azure::Nullable<T>::GetValue()` to `Value()`.
- Removed from `Azure::Core::Http::Request`:
  - `SetUploadChunkSize()`.
  - `GetHTTPMessagePreBody()`.
  - `GetUploadChunkSize()`.
  - `GetHeadersAsString()`.
- Changes to `Azure::Core::Http::RawResponse`:
  - Removed `SetHeader(std::string const& header)`
  - Removed `SetHeader(uint8_t const* const first, uint8_t const* const last)`.
  - Removed `GetMajorVersion()`.
  - Removed `GetMinorVersion()`.
  - Renamed `GetBodyStream()` to `ExtractBodyStream()`.
- Changes to `Azure::Core::Context`:
  - Removed `Get()` and `HasKey()` in favor of a new method `TryGetValue()`.
  - Changed input parameter type of `WithDeadline()` to `Azure::DateTime`.
- Removed `Azure::Core::PackageVersion`.
- Removed from `Azure::Core::Http::Policies` namespace: `HttpPolicyOrder`, `TransportPolicy`, `RetryPolicy`, `RequestIdPolicy`, `TelemetryPolicy`, `BearerTokenAuthenticationPolicy`, `LogPolicy`.
- Removed `AppendQueryParameters()`, `GetUrlWithoutQuery()` and `GetUrlAuthorityWithScheme()` from `Azure::Core::Url`.
- Changed the `Azure::Core::Http::HttpMethod` regular enum into an extensible enum class and removed the `HttpMethodToString()` helper method.
- Introduced `Azure::Core::Context::Key` class which takes place of `std::string` used for `Azure::Core::Context` keys previously.
- Changed the casing of `SSL` in API names to `Ssl`:
  - Renamed type `Azure::Core::Http::CurlTransportSSLOptions` to `CurlTransportSslOptions`.
  - Renamed member `Azure::Core::Http::CurlTransportOptions::SSLOptions` to `SslOptions`.
  - Renamed member `Azure::Core::Http::CurlTransportOptions::SSLVerifyPeer` to `SslVerifyPeer`.

### Other changes and Improvements

- Moved `Azure::Core::Http::Request` to its own header file from `http.hpp` to `inc/azure/core/http/raw_response.hpp`.
- Moved `Azure::Core::Http::HttpStatusCode` to its own header file from `http.hpp` to `inc/azure/core/http/http_status_code.hpp`.

* [azure-identity-cpp] Update to 1.0.0-beta.5
## 1.0.0-beta.5 (2021-04-07)

### New Features

- Add Active Directory Federation Service (ADFS) support to `ClientSecretCredential`.

### Breaking Changes

- Removed `Azure::Identity::PackageVersion`.

* [azure-storage-common-cpp] Update to 12.0.0-beta.10
## 12.0.0-beta.10 (2021-04-16)

### New Features

- Added server timeout support.
- Added `PagedResponse<T>` for returning paginated collections.

### Breaking Changes

- Removed `Azure::Storage::Common::PackageVersion`.
- Moved `ReliableStream` to internal namespace.
- Removed `HttpGetterInfo` and `HTTPGetter` from the `Azure::Storage` namespace.

* [azure-storage-blobs-cpp] Update to 12.0.0-beta.10
## 12.0.0-beta.10 (2021-04-16)

### Breaking Changes

- Removed `Azure::Storage::Blobs::PackageVersion`.
- Renamed `GetUserDelegationKeyOptions::startsOn` to `StartsOn`.
- Replaced all paginated collection functions that have the SinglePage suffix with pageable functions returning a `PagedResponse<T>`-derived type. The options are also renamed accordingly.
  - `BlobServiceClient::ListBlobContainers()`.
  - `BlobServiceClient::FindBlobsByTags()`.
  - `BlobContainerClinet::ListBlobs()`.
  - `BlobContainerClient::ListBlobsByHierarchy()`.
  - `PageBlobClient::GetPageRanges()`.
  - `PageBlobClient::GetPageRangesDiff()`.
  - `PageBlobClient::GetManagedDiskPageRangesDiff()`.
- Renamed `FilterBlobItem` to `TaggedBlobItem`.
  - `FindBlobsByTags()` now returns `FindBlobsByTagsPagedResponse` and the field `FindBlobsByTagsSinglePageResult::Items` was renamed to `FindBlobsByTagsPagedResponse::TaggedBlobs`.

* [azure-storage-files-datalake-cpp] Update to 12.0.0-beta.10
## 12.0.0-beta.10 (2021-04-16)

### Breaking Changes

- Removed `Azure::Storage::Files::DataLake::PackageVersion`.
- Renamed `GetUserDelegationKeyOptions::startsOn` to `StartsOn`.
- Replaced all paginated collection functions that have the SinglePage suffix with pageable functions returning a `PagedResponse<T>`-derived type. The options are also renamed accordingly.
  - `DataLakeServiceClient::ListFileSystems()`.
  - `DataLakeFileSystemClient::ListPaths()`.
  - `DataLakeDirectoryClient::ListPaths()`.
- Removed `DataLakePathClient::SetAccessControlListRecursiveSinglePage()`, `UpdateAccessControlListRecursiveSinglePage()` and `RemoveAccessControlListRecursiveSinglePage()`.

### Bug Fixes

- Rename functions always fail because `/` was left out in the renamed source path.

* [azure-storage-files-shares-cpp] Update to 12.0.0-beta.10
## 12.0.0-beta.10 (2021-04-16)

### Breaking Changes

- Removed `Azure::Storage::Files::Shares::PackageVersion`.
- Renamed `GetUserDelegationKeyOptions::startsOn` to `StartsOn`.
- Removed `ShareClient::ListFilesAndDirectories()`.
- Replaced all paginated collection functions that have the SinglePage suffix with pageable functions returning a `PagedResponse<T>`-derived type. The options are also renamed accordingly.
  - `ShareServiceClient::ListShares()`.
  - `ShareDirectoryClient::ListFilesAndDirectories()`.
  - `ShareDirectoryClient::ListHandles()`.
  - `ShareFileClient::ListHandles()`.
- Removed `ShareDirectoryClient::ForceCloseAllHandlesSinglePage()` and `ShareFileClient::ForceCloseAllHandlesSinglePage()`.

* Update vcpkg ports to use a manifest json file instead of a CONTROL file.

* Update git tree sha versions using the command 'x-add-version --all --overwrite-version'

Co-authored-by: Ahson Khan <ahkha@microsoft.com>
