### PR TITLE
Azure SDK May Release (#18002)

### DIFF
--- a/ports/azure-core-cpp/portfile.cmake
+++ b/ports/azure-core-cpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-core_1.0.0-beta.8
-    SHA512 fd882e37332fd5f35627b94c96cfae78178d9bc551cc9a27480f2ef08d496ea2379dc8d0e6a237e902ce063ae87ed6f9e8dc0b91e2e16bd8638e839f8d9e4c2a
+    REF azure-core_1.0.0-beta.9
+    SHA512 7d1bc802ed3b1ee3724ba258d8759fa04d614666eec1f5ec28abf665ee2c5af34148bb4682a9d8c8be2b9beec0ba886fc850c8333d3229ff6209d9116901fd84
 )
 
 vcpkg_check_features(

--- a/ports/azure-core-cpp/vcpkg.json
+++ b/ports/azure-core-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "azure-core-cpp",
-  "version-semver": "1.0.0-beta.8",
-  "port-version": 1,
+  "version-semver": "1.0.0-beta.9",
   "description": [
     "Microsoft Azure Core SDK for C++",
     "This library provides shared primitives, abstractions, and helpers for modern Azure SDK client libraries written in the C++."
@@ -27,7 +26,7 @@
   ],
   "features": {
     "curl": {
-      "description": "LibCURL HTTP transport implementation",
+      "description": "Libcurl HTTP transport implementation",
       "dependencies": [
         {
           "name": "azure-core-cpp",

--- a/ports/azure-identity-cpp/portfile.cmake
+++ b/ports/azure-identity-cpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-identity_1.0.0-beta.5
-    SHA512 9ff56d719d77c7b0db3054788dc69aee18105e27d0732d79b1eb7b86fd8e568dd52631aaf329c4b0f4c65699c2d8bda0a050586bcd8052cb1e74cb46f3f2c85a
+    REF azure-identity_1.0.0-beta.6
+    SHA512 0ed151a322049dfd2df8da43539ad5a81478866edb421c394e6937d886039d7d24f0b483cfd5e50655b590eb75ed4c5c42ed5a1760c51ea2eda81f7bf3b3114e
 )
 
 vcpkg_cmake_configure(

--- a/ports/azure-identity-cpp/vcpkg.json
+++ b/ports/azure-identity-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "azure-identity-cpp",
-  "version-semver": "1.0.0-beta.5",
-  "port-version": 1,
+  "version-semver": "1.0.0-beta.6",
   "description": [
     "Microsoft Azure Identity SDK for C++",
     "This library provides common authentication-related abstractions for Azure SDK."

--- a/ports/azure-security-keyvault-common-cpp/portfile.cmake
+++ b/ports/azure-security-keyvault-common-cpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-security-keyvault-common_4.0.0-beta.1
-    SHA512 7364bf775bbf6115bf54ee0c2df8b2bae35ea31c669fcbc358edd00a948f2c73926fbf88282ff5442f40ead9cdfc78661a08e4f86002ac2eac5e78ddd13eb33d
+    REF azure-security-keyvault-common_4.0.0-beta.2
+    SHA512 72b4fc7d6f5b85eebd64446bb2667f5384ee0fdf7aee4443baa57038d4274d850b0c00e1a5a75c13516fe805f96df968f671cd65d9c4efd74d953fbc22b0291a
 )
 
 vcpkg_cmake_configure(

--- a/ports/azure-security-keyvault-common-cpp/vcpkg.json
+++ b/ports/azure-security-keyvault-common-cpp/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "azure-security-keyvault-common-cpp",
-  "version-semver": "4.0.0-beta.1",
-  "port-version": 1,
+  "version-semver": "4.0.0-beta.2",
   "description": [
     "Microsoft Azure Common Key Vault SDK for C++",
-    "This library provides common Azure KeyVault-related abstractions for Azure SDK."
+    "This library provides common Azure Key Vault related abstractions for Azure SDK."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/master/sdk/keyvault/azure-security-keyvault-common",
   "license": "MIT",

--- a/ports/azure-security-keyvault-keys-cpp/portfile.cmake
+++ b/ports/azure-security-keyvault-keys-cpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-security-keyvault-keys_4.0.0-beta.1
-    SHA512 fb5158320c859f27c97c86908fd4c3f7ceec2ec8b0ca3c213a075992b62dfdefa3a560173bc7034153c273c30abd7fd0a84f98842810de2f78412549e5d34ee4
+    REF azure-security-keyvault-keys_4.0.0-beta.2
+    SHA512 ce609e31228705f3fae81da2f2938a1ef3b59d5b6f771b752aad78eddfe8f20cebca9b92de24e8a6cac84df468d24bf314ebce10cf62c7c8fe201bd3600034ce
 )
 
 vcpkg_cmake_configure(

--- a/ports/azure-security-keyvault-keys-cpp/vcpkg.json
+++ b/ports/azure-security-keyvault-keys-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "azure-security-keyvault-keys-cpp",
-  "version-semver": "4.0.0-beta.1",
-  "port-version": 1,
+  "version-semver": "4.0.0-beta.2",
   "description": [
     "Microsoft Azure Key Vault Keys SDK for C++",
     "This library provides Azure Key Vault Keys SDK."

--- a/ports/azure-storage-blobs-cpp/portfile.cmake
+++ b/ports/azure-storage-blobs-cpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-storage-blobs_12.0.0-beta.10
-    SHA512 d8afc221f8132fefd7a56cb0fb22549bce3b2b35bc532f43e0f37335f9cc46389028b51068813240f9b083c87b78a3007240cbaf37a5d9dd96b94e002fbc945f
+    REF azure-storage-blobs_12.0.0-beta.11
+    SHA512 925a8a89fcd4c275e7c73131941a0c195bad33c66c2ec556297abd5606f543d13dfb704dbccb619ac127c807feec34ef027dc9a027441a524e23b2919010b15a
 )
 
 vcpkg_cmake_configure(

--- a/ports/azure-storage-blobs-cpp/vcpkg.json
+++ b/ports/azure-storage-blobs-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "azure-storage-blobs-cpp",
-  "version-semver": "12.0.0-beta.10",
-  "port-version": 1,
+  "version-semver": "12.0.0-beta.11",
   "description": [
     "Microsoft Azure Storage Blobs SDK for C++",
     "This library provides Azure Storage Blobs SDK."

--- a/ports/azure-storage-common-cpp/portfile.cmake
+++ b/ports/azure-storage-common-cpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-storage-common_12.0.0-beta.10
-    SHA512 f49f74c9a6d7b80b0f7c8a9b9d2e4595dc304439d30c8c83f520833f81ef7d3480b858ada61c12f76e82eea7960eb155453b0acdcea143f163a12d567adbf18d
+    REF azure-storage-common_12.0.0-beta.11
+    SHA512 c95aaba165d0a7432badc583b18f16af2f0bbe5a8b29e898ae5a8832ddf124d37a2cbcef047f8c165f5322f482f1b63523fdf342284d120e550904fb86c2f20d
 )
 
 vcpkg_cmake_configure(

--- a/ports/azure-storage-common-cpp/vcpkg.json
+++ b/ports/azure-storage-common-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "azure-storage-common-cpp",
-  "version-semver": "12.0.0-beta.10",
-  "port-version": 1,
+  "version-semver": "12.0.0-beta.11",
   "description": [
     "Microsoft Azure Common Storage SDK for C++",
     "This library provides common Azure Storage-related abstractions for Azure SDK."

--- a/ports/azure-storage-files-datalake-cpp/portfile.cmake
+++ b/ports/azure-storage-files-datalake-cpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-storage-files-datalake_12.0.0-beta.10
-    SHA512 9b8f2acbb8cfae1acd4275bca9d9d1a4c9f77a4a38484c88fc89a2081554d4ca6ed64f79a5102ee303c2c72648229e46ff282309868cda8f69f69389747d7e9d
+    REF azure-storage-files-datalake_12.0.0-beta.11
+    SHA512 68af6f25b36e10a09371a4f31603b65124692953848960d38fdcb220f141d942f4b4bb4790541d9502fc5e18315a4eb98cd5cba64d878f05a3aa913da0a83bb6
 )
 
 vcpkg_cmake_configure(

--- a/ports/azure-storage-files-datalake-cpp/vcpkg.json
+++ b/ports/azure-storage-files-datalake-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "azure-storage-files-datalake-cpp",
-  "version-semver": "12.0.0-beta.10",
-  "port-version": 1,
+  "version-semver": "12.0.0-beta.11",
   "description": [
     "Microsoft Azure Storage Files Data Lake SDK for C++",
     "This library provides Azure Storage Files Data Lake SDK."

--- a/ports/azure-storage-files-shares-cpp/portfile.cmake
+++ b/ports/azure-storage-files-shares-cpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-storage-files-shares_12.0.0-beta.10
-    SHA512 028e60284f59849ab331ccd5ba7b650ac8ecdf7fc3a2d8eda60b29f88c78e7fb9166eb10e021feafa630a103c036f24c84951c729da1a8766fa028b7f9d7ebbd
+    REF azure-storage-files-shares_12.0.0-beta.11
+    SHA512 572baaceb4b8d6bd8eb96f6823c005654065212073c31087977da00dc92766e110bd7901a190c2708054a84e93fff55394032f49966d27909ce71f7efeff5b18
 )
 
 vcpkg_cmake_configure(

--- a/ports/azure-storage-files-shares-cpp/vcpkg.json
+++ b/ports/azure-storage-files-shares-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "azure-storage-files-shares-cpp",
-  "version-semver": "12.0.0-beta.10",
-  "port-version": 1,
+  "version-semver": "12.0.0-beta.11",
   "description": [
     "Microsoft Azure Storage Files Shares SDK for C++",
     "This library provides Azure Storage Files Shares SDK."

--- a/versions/a-/azure-core-cpp.json
+++ b/versions/a-/azure-core-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5f331c1e92da2947207db42ba2bba398cf19470b",
+      "version-semver": "1.0.0-beta.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "48c994ba970ba698f09e0dcc425947f5b9b8b865",
       "version-semver": "1.0.0-beta.8",
       "port-version": 1

--- a/versions/a-/azure-identity-cpp.json
+++ b/versions/a-/azure-identity-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5b1607f9afe53751e0468408b96d10be8712fd2a",
+      "version-semver": "1.0.0-beta.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "bf9a1c77957b02e2b1521fc5847d4c8ab617ebcd",
       "version-semver": "1.0.0-beta.5",
       "port-version": 1

--- a/versions/a-/azure-security-keyvault-common-cpp.json
+++ b/versions/a-/azure-security-keyvault-common-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "427e0adc6e385b009d892345c04b9e180d68e3cd",
+      "version-semver": "4.0.0-beta.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "c3e9761add3c0ad93a038ab859d288e64fc7860e",
       "version-semver": "4.0.0-beta.1",
       "port-version": 1

--- a/versions/a-/azure-security-keyvault-keys-cpp.json
+++ b/versions/a-/azure-security-keyvault-keys-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "21cbc7aa281189b4bd3364f1dc044aad8218ebfb",
+      "version-semver": "4.0.0-beta.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "030fd5b9588b63350781bb875a3fc2d67d0d13f0",
       "version-semver": "4.0.0-beta.1",
       "port-version": 1

--- a/versions/a-/azure-storage-blobs-cpp.json
+++ b/versions/a-/azure-storage-blobs-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "25b1c91e5691dd97ee644321ead2e5880bede739",
+      "version-semver": "12.0.0-beta.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "62d9013672397f9c80ae95611cb7318b649b92ec",
       "version-semver": "12.0.0-beta.10",
       "port-version": 1

--- a/versions/a-/azure-storage-common-cpp.json
+++ b/versions/a-/azure-storage-common-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5751a578e18097edc570960298c5275e7166fc0f",
+      "version-semver": "12.0.0-beta.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "e088ce294ef101d5d4be7621973121ba1105c408",
       "version-semver": "12.0.0-beta.10",
       "port-version": 1

--- a/versions/a-/azure-storage-files-datalake-cpp.json
+++ b/versions/a-/azure-storage-files-datalake-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "700c9eee3d84a215c27fb452e814da58d079086c",
+      "version-semver": "12.0.0-beta.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "a067bf73d77aa871c394d7972db69939940c114f",
       "version-semver": "12.0.0-beta.10",
       "port-version": 1

--- a/versions/a-/azure-storage-files-shares-cpp.json
+++ b/versions/a-/azure-storage-files-shares-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1d1a11e7f5f6603ae6f3c42d6d2821b16261726f",
+      "version-semver": "12.0.0-beta.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "aa4d77e84688efab3d4f4771a90a586fc8c0dc90",
       "version-semver": "12.0.0-beta.10",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -253,12 +253,12 @@
       "port-version": 1
     },
     "azure-core-cpp": {
-      "baseline": "1.0.0-beta.8",
-      "port-version": 1
+      "baseline": "1.0.0-beta.9",
+      "port-version": 0
     },
     "azure-identity-cpp": {
-      "baseline": "1.0.0-beta.5",
-      "port-version": 1
+      "baseline": "1.0.0-beta.6",
+      "port-version": 0
     },
     "azure-iot-sdk-c": {
       "baseline": "2020-12-09",
@@ -273,32 +273,32 @@
       "port-version": 2
     },
     "azure-security-keyvault-common-cpp": {
-      "baseline": "4.0.0-beta.1",
-      "port-version": 1
+      "baseline": "4.0.0-beta.2",
+      "port-version": 0
     },
     "azure-security-keyvault-keys-cpp": {
-      "baseline": "4.0.0-beta.1",
-      "port-version": 1
+      "baseline": "4.0.0-beta.2",
+      "port-version": 0
     },
     "azure-storage-blobs-cpp": {
-      "baseline": "12.0.0-beta.10",
-      "port-version": 1
+      "baseline": "12.0.0-beta.11",
+      "port-version": 0
     },
     "azure-storage-common-cpp": {
-      "baseline": "12.0.0-beta.10",
-      "port-version": 1
+      "baseline": "12.0.0-beta.11",
+      "port-version": 0
     },
     "azure-storage-cpp": {
       "baseline": "7.5.0",
       "port-version": 0
     },
     "azure-storage-files-datalake-cpp": {
-      "baseline": "12.0.0-beta.10",
-      "port-version": 1
+      "baseline": "12.0.0-beta.11",
+      "port-version": 0
     },
     "azure-storage-files-shares-cpp": {
-      "baseline": "12.0.0-beta.10",
-      "port-version": 1
+      "baseline": "12.0.0-beta.11",
+      "port-version": 0
     },
     "azure-uamqp-c": {
       "baseline": "2020-12-09",


### PR DESCRIPTION
* [azure-core-cpp] Update to 1.0.0-beta.9
## 1.0.0-beta.9 (2021-05-18)

### New Features

- Added `Azure::PagedResponse<T>`.

### Breaking Changes

- Added `final` specifier to classes and structures that are are not expected to be inheritable at the moment.
- Removed `Context::GetApplicationContext()` in favor of a new static data member `Context::ApplicationContext`.
- Renamed `Request::IsDownloadViaStream()` to `ShouldBufferResponse()`.
- Removed the `Azure::Core::Http::Request` ctor overload that takes both a `bodyStream` and a `bufferedDownload` boolean since it is not useful.
- Changed integer size parameters for buffers from `int64_t` to `size_t` in various places such as `Azure::Core::IO::BodyStream::Read()` APIs.
- Removed the `Azure::Core::Diagnostics::Logger::Listener` typedef.

### Bug Fixes

- Do not re-use a libcurl connection to same host but different port.
- Fixed curl transport issue to avoid crash at exit when curl connection pool cleanup thread is running.
- Ensure uniqueness of `Azure::Core::Uuid` on POSIX platforms.

### Other Changes and Improvements

- Modified precondition validation of function arguments to now result in assert failures rather than throwing an exception.
- Remove exposing windows.h header from our public headers.
- Improved performance of the WinHTTP transport layer on Windows for uploading large payloads.

* [azure-identity-cpp] Update to 1.0.0-beta.6
## 1.0.0-beta.6 (2021-05-18)

### Breaking Changes

- Added `final` specifier to classes and structures that are are not expected to be inheritable at the moment.

* [azure-security-keyvault-common-cpp] Update to 4.0.0-beta.2
## 4.0.0-beta.2 (2021-05-18)

### Breaking Changes

- Added `final` specifier to classes and structures that are are not expected to be inheritable at the moment.
- Removed `KeyVaultException`.
- Removed `ClientOptions`.

* [azure-security-keyvault-keys-cpp] Update to 4.0.0-beta.2
## 4.0.0-beta.2 (2021-05-18)

### New Features

- Added support for importing and deserializing EC and OCT keys.
- Added cryptography client.
- Added `CreateFromResumeToken()` to `DeletedKeyOperation` and `RecoverKeyOperation`.

### Breaking Changes

- Added `final` specifier to classes and structures that are are not expected to be inheritable at the moment.
- Renamed `GetPropertiesOfKeysSinglePage()` to `GetPropertiesOfKeys()`.
- Renamed `GetPropertiesOfKeyVersionsSinglePage()` to `GetPropertiesOfKeyVersions()`.
- Renamed `GetDeletedKeysSinglePage()` to `GetDeletedKeys()`.
- Renamed `KeyPropertiesSinglePage` to `KeyPropertiesPageResult`.
- Renamed `DeletedKeySinglePage` to `DeletedKeyPageResult`.
- Renamed `GetPropertiesOfKeysSinglePageOptions` to `GetPropertiesOfKeysOptions`.
- Renamed `GetPropertiesOfKeyVersionsSinglePageOptions` to `GetPropertiesOfKeyVersionsOptions`.
- Renamed `GetDeletedKeysSinglePageOptions` to `GetDeletedKeysOptions`.
- Removed `Azure::Security::KeyVault::Keys::JsonWebKey::to_json`.
- Replaced static functions from `KeyOperation` and `KeyCurveName` with static const members.
- Replaced the enum `JsonWebKeyType` for a class with static const members as an extensible enum called `KeyVaultKeyType`.
- Renamed `MaxResults` to `MaxPageResults` for `GetSinglePageOptions`.
- Changed the returned type for list keys, key versions, and deleted keys from `Response<T>` to `PagedResponse<T>` affecting:
  - `GetPropertiesOfKeysSinglePage()` and `GetPropertiesOfKeyVersionsSinglePage()` now returns `KeyProperties`.
  - `GetDeletedKeysSinglePage()` now returns `DeletedKey`.
- Removed `ResumeDeleteKeyOperation()` and `ResumeRecoverKeyOperation()`.

### Bug Fixes

- Fix getting a resume token from delete and recover key operations.

* [azure-storage-common-cpp] Update to 12.0.0-beta.11
## 12.0.0-beta.11 (2021-05-19)

### Breaking Changes

- Added `final` specifier to classes and structures that are are not expected to be inheritable at the moment.
- Removed `Azure::PagedResponse<T>`.

### Bug Fixes

- Fixed a stream leak issue in `ReliableStream`.

* [azure-storage-blobs-cpp] Update to 12.0.0-beta.11
## 12.0.0-beta.11 (2021-05-19)

### Breaking Changes

- Added `final` specifier to classes and structures that are are not expected to be inheritable at the moment.
- Renamed `HasMorePages()` in paged response to `HasPage()`.
- Default chunk size for concurrent upload was changed to nullable.
- `BlobLeaseClient::Change()` updates internal lease id.
- Removed `ContentType` from `GetBlockListResult`.
- Moved `GetPageRangesResult` to detail namespace.
- `BlobServiceClient::UndeleteBlobContainer` doesn't support restoring a deleted container under a different name anymore.
- Changed the type of block count to `int32_t`.

* [azure-storage-files-datalake-cpp] Update to 12.0.0-beta.11
## 12.0.0-beta.11 (2021-05-19)

### New Features

- Added `DataLakePathClient::SetAccessControlListRecursive()`, `UpdateAccessControlListRecursive()` and `RemoveAccessControlListRecursive()`.

### Breaking Changes

- Added `final` specifier to classes and structures that are are not expected to be inheritable at the moment.
- Renamed `HasMorePages()` in paged response to `HasPage()`.
- Default chunk size for concurrent upload was changed to nullable.
- `DataLakeLeaseClient::Change()` updates internal lease id.

* [azure-storage-files-shares-cpp] Update to 12.0.0-beta.11
## 12.0.0-beta.11 (2021-05-19)

### New Features

- Added `ShareDirectoryClient::ForceCloseAllHandles()` and `ShareFileClient::ForceCloseAllHandles()`.

### Breaking Changes

- Added `final` specifier to classes and structures that are are not expected to be inheritable at the moment.
- Renamed `HasMorePages()` in paged response to `HasPage()`.
- `ShareLeaseClient::Change()` updates internal lease id.
- `ShareItem::ShareMetadata` was renamed to `ShareItem::Metadata`.
