### PR TITLE
[vcpkg baseline][tensorflow] Skip osx check in baseline (#18812)

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1794,4 +1794,5 @@ dimcli:x64-windows-static=fail
 cppgraphqlgen:x64-osx=fail
 
 # Changes in Python have broken tensorflow on our osx hardware
+tensorflow:x64-osx=fail
 tensorflow-cc:x64-osx=fail


### PR DESCRIPTION
Merge from microsoft/vcpkg