### PR TITLE
[rtmidi] Fix fatal error C1083: Cannot open include file: jack/jack.h…

### DIFF
--- a/ports/rtmidi/CONTROL
+++ b/ports/rtmidi/CONTROL
@@ -1,6 +1,0 @@
-Source: rtmidi
-Version: 4.0.0
-Port-Version: 2
-Homepage: https://github.com/thestk/rtmidi
-Description: A set of C++ classes that provide a common API for realtime MIDI input/output across Linux (ALSA & JACK), Macintosh OS X (CoreMidi & JACK) and Windows (Multimedia)
-Supports: !uwp

--- a/ports/rtmidi/portfile.cmake
+++ b/ports/rtmidi/portfile.cmake
@@ -15,15 +15,16 @@ vcpkg_from_github(
 )
 
 vcpkg_configure_cmake(
-  SOURCE_PATH ${SOURCE_PATH}
-  PREFER_NINJA
-  OPTIONS_DEBUG -DDISABLE_INSTALL_HEADERS=ON
-  OPTIONS -DRTMIDI_API_ALSA=OFF
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DRTMIDI_API_ALSA=OFF
+        -DRTMIDI_API_JACK=OFF
 )
 
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL ${SOURCE_PATH}/README.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/README.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/rtmidi/vcpkg.json
+++ b/ports/rtmidi/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "rtmidi",
+  "version-semver": "4.0.0",
+  "port-version": 3,
+  "description": "A set of C++ classes that provide a common API for realtime MIDI input/output across Linux (ALSA & JACK), Macintosh OS X (CoreMidi & JACK) and Windows (Multimedia)",
+  "homepage": "https://github.com/thestk/rtmidi",
+  "supports": "!uwp"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5666,7 +5666,7 @@
     },
     "rtmidi": {
       "baseline": "4.0.0",
-      "port-version": 2
+      "port-version": 3
     },
     "rttr": {
       "baseline": "0.9.6-2",

--- a/versions/r-/rtmidi.json
+++ b/versions/r-/rtmidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4c13583da321fa3efa7a075032d0ed880dd15e48",
+      "version-semver": "4.0.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "65614f322a89cff92478b3f6736d287653085a34",
       "version-string": "4.0.0",
       "port-version": 2


### PR DESCRIPTION
… (#19458)

* [rtmidi] Fix fatal error C1083: Cannot open include file:jack/jack.h

* Update json file

* Modify the format of portfile.cmake

* Update json

**Describe the pull request**

- #### What does your PR fix?  
  Fixes #...

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  <all / linux, windows, ...>, <Yes/No>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Your answer`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  <Yes / I am still working on this PR>

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
