### PR TITLE
[boost] fix boost-mpi dependency (#20681)

### DIFF
--- a/ports/boost/vcpkg.json
+++ b/ports/boost/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "boost",
   "version": "1.77.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Peer-reviewed portable C++ source libraries",
   "homepage": "https://boost.org",
   "dependencies": [
@@ -137,7 +137,6 @@
     },
     "boost-program-options",
     "boost-property-map",
-    "boost-property-map-parallel",
     "boost-property-tree",
     "boost-proto",
     "boost-ptr-container",
@@ -202,7 +201,8 @@
       "description": "Build with MPI support",
       "dependencies": [
         "boost-graph-parallel",
-        "boost-mpi"
+        "boost-mpi",
+        "boost-property-map-parallel"
       ]
     }
   }

--- a/scripts/boost/generate-ports.ps1
+++ b/scripts/boost/generate-ports.ps1
@@ -24,7 +24,7 @@ else {
 # Clear this array when moving to a new boost version
 $portVersions = @{
     #e.g. "boost-asio" = 1;
-    "boost"                      = 1;
+    "boost"                      = 2;
     "boost-config"               = 2;
     "boost-gil"                  = 1;
     "boost-iostreams"            = 1;
@@ -39,7 +39,7 @@ $portData = @{
         "features" = @{
             "mpi" = @{
                 "description"  = "Build with MPI support";
-                "dependencies" = @("boost-mpi", "boost-graph-parallel");
+                "dependencies" = @("boost-mpi", "boost-graph-parallel", "boost-property-map-parallel");
             }
         }
     };

--- a/versions/b-/boost.json
+++ b/versions/b-/boost.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "19bdc0542dd287e39768144ba2719723a7818750",
+      "version": "1.77.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "5fe225d8d76e70968014f7ddab050d7e520709e6",
       "version": "1.77.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -506,7 +506,7 @@
     },
     "boost": {
       "baseline": "1.77.0",
-      "port-version": 1
+      "port-version": 2
     },
     "boost-accumulators": {
       "baseline": "1.77.0",


### PR DESCRIPTION
Merge from microsoft/vcpkg