### PR TITLE
[getopt-win32] ARM64 support (#24963)

### DIFF
--- a/ports/getopt-win32/CMakeLists.txt
+++ b/ports/getopt-win32/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(getopt-win32 C)
+
+if(BUILD_SHARED_LIBS)
+    add_definitions(-DEXPORTS_GETOPT)
+else()
+    add_definitions(-DSTATIC_GETOPT)
+endif()
+add_library(getopt getopt.c)
+install(TARGETS getopt)

--- a/ports/getopt-win32/portfile.cmake
+++ b/ports/getopt-win32/portfile.cmake
@@ -1,7 +1,3 @@
-if(VCPKG_CMAKE_SYSTEM_NAME)
-    message(FATAL_ERROR "getopt-win32 only supports building on Windows Desktop")
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libimobiledevice-win32/getopt
@@ -11,38 +7,17 @@ vcpkg_from_github(
     PATCHES getopt.h.patch
 )
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    list(APPEND OPTIONS "/p:ConfigurationType=StaticLibrary")
-else()
-    list(APPEND OPTIONS "/p:ConfigurationType=DynamicLibrary")
-endif()
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
-set(_file "${SOURCE_PATH}/getopt.vcxproj")
-file(READ "${_file}" _contents)
-if(VCPKG_CRT_LINKAGE STREQUAL static)
-    string(REPLACE "<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>" "<RuntimeLibrary>MultiThreaded</RuntimeLibrary>" _contents "${_contents}")
-    string(REPLACE "<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>" "<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>" _contents "${_contents}")
-else()
-    string(REPLACE "<RuntimeLibrary>MultiThreaded</RuntimeLibrary>" "<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>" _contents "${_contents}")
-    string(REPLACE "<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>"  "<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>" _contents "${_contents}")
-endif()
-file(WRITE "${_file}" "${_contents}")
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_install()
 
-
-
-vcpkg_install_msbuild(
-    SOURCE_PATH ${SOURCE_PATH}
-    PROJECT_SUBPATH getopt.vcxproj
-    LICENSE_SUBPATH LICENSE
-    OPTIONS ${OPTIONS}
-)
-
-# Copy header
 file(COPY "${SOURCE_PATH}/getopt.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/")
-if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/getopt.h"
         "	#define __GETOPT_H_" "	#define __GETOPT_H_\n	#define STATIC_GETOPT"
     )
 endif()
 
+configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
 set(VCPKG_POLICY_ALLOW_RESTRICTED_HEADERS enabled)

--- a/ports/getopt-win32/vcpkg.json
+++ b/ports/getopt-win32/vcpkg.json
@@ -1,9 +1,15 @@
 {
   "name": "getopt-win32",
   "version": "0.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "An implementation of getopt.",
-  "homepage": "https://github.com/libimobiledevice-win32",
+  "homepage": "https://github.com/libimobiledevice-win32/getopt",
   "license": "LGPL-3.0-only",
-  "supports": "windows & !mingw"
+  "supports": "windows & !mingw",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
 }

--- a/ports/graphviz/vcpkg.json
+++ b/ports/graphviz/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "graphviz",
   "version-semver": "2.49.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Graph Visualization Tools",
   "homepage": "https://graphviz.org/",
   "license": "EPL-1.0",
+  "supports": "!(windows & arm64)",
   "dependencies": [
     "cairo",
     "getopt",

--- a/ports/ideviceinstaller/vcpkg.json
+++ b/ports/ideviceinstaller/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "ideviceinstaller",
   "version-string": "1.1.2.23",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Manage apps of iOS devices",
+  "supports": "!(windows & arm64)",
   "dependencies": [
     "libimobiledevice",
     "libzip"

--- a/ports/libirecovery/vcpkg.json
+++ b/ports/libirecovery/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "libirecovery",
   "version-string": "1.0.25",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Library and utility to talk to iBoot/iBSS via USB on Mac OS X, Windows, and Linux",
+  "supports": "!(windows & arm64)",
   "dependencies": [
     "getopt",
     "libusbmuxd",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -302,7 +302,6 @@ geotrans:x64-windows         = skip
 geotrans:x86-windows         = skip
 getopt:arm-uwp=fail
 getopt:x64-uwp=fail
-getopt-win32:arm64-windows=fail
 getopt-win32:arm-uwp=fail
 getopt-win32:x64-linux=fail
 getopt-win32:x64-osx=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2490,7 +2490,7 @@
     },
     "getopt-win32": {
       "baseline": "0.1",
-      "port-version": 3
+      "port-version": 4
     },
     "gettext": {
       "baseline": "0.21",
@@ -2650,7 +2650,7 @@
     },
     "graphviz": {
       "baseline": "2.49.1",
-      "port-version": 3
+      "port-version": 4
     },
     "greatest": {
       "baseline": "1.5.0",
@@ -2834,7 +2834,7 @@
     },
     "ideviceinstaller": {
       "baseline": "1.1.2.23",
-      "port-version": 2
+      "port-version": 3
     },
     "idevicerestore": {
       "baseline": "1.0.12",
@@ -3698,7 +3698,7 @@
     },
     "libirecovery": {
       "baseline": "1.0.25",
-      "port-version": 3
+      "port-version": 4
     },
     "libjpeg-turbo": {
       "baseline": "2.1.3",

--- a/versions/g-/getopt-win32.json
+++ b/versions/g-/getopt-win32.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a655b35c38424570406603859dcfbb70d25bc0b9",
+      "version": "0.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "97ccee735c01df1356a70d59bc114512f7ab77cc",
       "version": "0.1",
       "port-version": 3

--- a/versions/g-/graphviz.json
+++ b/versions/g-/graphviz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "14f5333a2eb91b052b2691132f48aefced3bf1df",
+      "version-semver": "2.49.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "c1f20d0e1aaccb1035e3fe3eb95d005b4161a56e",
       "version-semver": "2.49.1",
       "port-version": 3

--- a/versions/i-/ideviceinstaller.json
+++ b/versions/i-/ideviceinstaller.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "38626b7d6489e6842528257d8a38b2dd31627720",
+      "version-string": "1.1.2.23",
+      "port-version": 3
+    },
+    {
       "git-tree": "3f0f8f093c1597406cdf0695b26403a2ec969baa",
       "version-string": "1.1.2.23",
       "port-version": 2

--- a/versions/l-/libirecovery.json
+++ b/versions/l-/libirecovery.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1396dbed8e08ee556ad00ce3a67ba0de7c7b6298",
+      "version-string": "1.0.25",
+      "port-version": 4
+    },
+    {
       "git-tree": "8e5ca128c3c62e747f3cc4beaeb0f5d74b263403",
       "version-string": "1.0.25",
       "port-version": 3


### PR DESCRIPTION
* [getopt-win32] ARM64 support

* retrigger checks

* updated git-tree sha

* Specify ports that do not support ARM but were enabled by getopt-win32 adding support.

* Upated SHA's

* Update ports/getopt-win32/portfile.cmake

Formatting indentation fix.

Co-authored-by: Mengna Li <95600143+Adela0814@users.noreply.github.com>

* Formatting indentation fix.

* Update version database

* [getopt-win32] Use CMake

* Updating versions

Co-authored-by: Mengna Li <95600143+Adela0814@users.noreply.github.com>
Co-authored-by: Robert Schumacher <roschuma@microsoft.com>
