### PR TITLE
[directx-dxc] port added to provide latest DirectX 12 HLSL Shader Com…

### DIFF
--- a/ports/directx-dxc/directx-dxc-config.cmake.in
+++ b/ports/directx-dxc/directx-dxc-config.cmake.in
@@ -1,0 +1,29 @@
+
+get_filename_component(_dxc_root "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(_dxc_root "${_dxc_root}" PATH)
+get_filename_component(_dxc_root "${_dxc_root}" PATH)
+
+set(_dxc_exe "${_dxc_root}/tools/directx-dxc/dxc.exe")
+if (EXISTS "${_dxc_exe}")
+
+   add_library(Microsoft::DirectXShaderCompiler SHARED IMPORTED)
+   set_target_properties(Microsoft::DirectXShaderCompiler PROPERTIES
+      IMPORTED_LOCATION_RELEASE            "${_dxc_root}/bin/dxcompiler.dll"
+      IMPORTED_LOCATION_DEBUG              "${_dxc_root}/bin/dxcompiler.dll"
+      IMPORTED_IMPLIB_RELEASE              "${_dxc_root}/lib/dxcompiler.lib"
+      IMPORTED_IMPLIB_DEBUG                "${_dxc_root}/lib/dxcompiler.lib"
+      INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include"
+      IMPORTED_CONFIGURATIONS              "Debug;Release"
+      IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
+
+    set(directx-dxc_FOUND TRUE)
+    set(DIRECTX_DXC_TOOL ${_dxc_exe})
+
+else()
+
+    set(directx-dxc_FOUND FALSE)
+
+endif()
+
+unset(_dxc_exe)
+unset(_dxc_root)

--- a/ports/directx-dxc/portfile.cmake
+++ b/ports/directx-dxc/portfile.cmake
@@ -1,0 +1,46 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.6.2112/dxc_2021_12_08.zip"
+    FILENAME "dxc_2021_12_08.zip"
+    SHA512 e9b36e896c1d47b39b648adbecf44da7f8543216fd1df539760f0c591907aea081ea6bfc59eb927073aaa1451110c5dc63003546509ff84c9e4445488df97c27
+)
+
+vcpkg_download_distfile(
+    LICENSE_TXT
+    URLS "https://raw.githubusercontent.com/microsoft/DirectXShaderCompiler/v1.6.2112/LICENSE.TXT"
+    FILENAME "LICENSE.v1.6.2112"
+    SHA512 7589f152ebc3296dca1c73609a2a23a911b8fc0029731268a6151710014d82005a868c85c8249219f060f64ab1ddecdddff5ed6ea34ff509f63ea3e42bbbf47e
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH PACKAGE_PATH
+    ARCHIVE ${ARCHIVE}
+    NO_REMOVE_ONE_LEVEL
+)
+
+file(INSTALL "${PACKAGE_PATH}/inc/d3d12shader.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
+file(INSTALL "${PACKAGE_PATH}/inc/dxcapi.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
+
+file(INSTALL "${PACKAGE_PATH}/lib/x64/dxcompiler.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+file(INSTALL "${PACKAGE_PATH}/lib/x64/dxcompiler.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+
+file(COPY "${PACKAGE_PATH}/bin/x64/dxcompiler.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+file(COPY "${PACKAGE_PATH}/bin/x64/dxcompiler.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+
+file(COPY "${PACKAGE_PATH}/bin/x64/dxil.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+file(COPY "${PACKAGE_PATH}/bin/x64/dxil.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}/")
+
+file(INSTALL
+  "${PACKAGE_PATH}/bin/x64/dxc.exe"
+  "${PACKAGE_PATH}/bin/x64/dxcompiler.dll"
+  "${PACKAGE_PATH}/bin/x64/dxil.dll"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${LICENSE_TXT}" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/directx-dxc-config.cmake.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake" COPYONLY)

--- a/ports/directx-dxc/vcpkg.json
+++ b/ports/directx-dxc/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "name": "directx-dxc",
+  "version-date": "2021-12-08",
+  "description": "DirectX Shader Compiler (LLVM/Clang)",
+  "homepage": "https://github.com/microsoft/DirectXShaderCompiler",
+  "documentation": "https://github.com/microsoft/DirectXShaderCompiler/wiki",
+  "license": null,
+  "supports": "windows & x64 & !uwp & !staticcrt"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1864,6 +1864,10 @@
       "baseline": "5.0.2",
       "port-version": 3
     },
+    "directx-dxc": {
+      "baseline": "2021-12-08",
+      "port-version": 0
+    },
     "directx-headers": {
       "baseline": "1.602.0",
       "port-version": 0

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "6f2dfd1c848d67e0f36d83b8a6e7078b96d82df1",
+      "version-date": "2021-12-08",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
…piler (#25020)

* [directx-dxc] new port for DirectX HLSL Compiler

* Reformat

* Update baseline

* It's not strictly a tool only port

* Update baseline

* Code review feedback

* Update baseline

* Update ports/directx-dxc/portfile.cmake

Co-authored-by: Cheney Wang <38240633+Cheney-W@users.noreply.github.com>

* Update ports/directx-dxc/portfile.cmake

Co-authored-by: Cheney Wang <38240633+Cheney-W@users.noreply.github.com>

* Update ports/directx-dxc/portfile.cmake

Co-authored-by: Cheney Wang <38240633+Cheney-W@users.noreply.github.com>

* Refresh baseline

Co-authored-by: Cheney Wang <38240633+Cheney-W@users.noreply.github.com>
