### PR TITLE
[ms-quic] Remove from ci.baseline.txt and fix UWP builds. (#39498)

### DIFF
--- a/ports/ms-quic/fix-comparing-system-processor-with-win32.patch
+++ b/ports/ms-quic/fix-comparing-system-processor-with-win32.patch
@@ -1,0 +1,22 @@
+diff --git a/submodules/CMakeLists.txt b/submodules/CMakeLists.txt
+index a6c592951..0a0ddf0f8 100644
+--- a/submodules/CMakeLists.txt
++++ b/submodules/CMakeLists.txt
+@@ -62,7 +62,7 @@ if (WIN32)
+             set(QUIC_OPENSSL_WIN_ARCH "VC-WIN64-ARM")
+         elseif (${SYSTEM_PROCESSOR} STREQUAL "arm")
+             set(QUIC_OPENSSL_WIN_ARCH "VC-WIN32-ARM")
+-        elseif (${SYSTEM_PROCESSOR} STREQUAL "win32")
++        elseif (${SYSTEM_PROCESSOR} STREQUAL "x86")
+             set(QUIC_OPENSSL_WIN_ARCH "VC-WIN32-ONECORE")
+         elseif (${SYSTEM_PROCESSOR} STREQUAL "x64" OR ${SYSTEM_PROCESSOR} STREQUAL "amd64")
+             set(QUIC_OPENSSL_WIN_ARCH "VC-WIN64A-ONECORE")
+@@ -75,7 +75,7 @@ if (WIN32)
+             set(QUIC_OPENSSL_WIN_ARCH "VC-WIN64-ARM")
+         elseif (${SYSTEM_PROCESSOR} STREQUAL "arm")
+             set(QUIC_OPENSSL_WIN_ARCH "VC-WIN32-ARM")
+-        elseif (${SYSTEM_PROCESSOR} STREQUAL "win32")
++        elseif (${SYSTEM_PROCESSOR} STREQUAL "x86")
+             set(QUIC_OPENSSL_WIN_ARCH "VC-WIN32")
+         elseif (${SYSTEM_PROCESSOR} STREQUAL "x64" OR ${SYSTEM_PROCESSOR} STREQUAL "amd64")
+             set(QUIC_OPENSSL_WIN_ARCH "VC-WIN64A")

--- a/ports/ms-quic/fix-uwp-crt.patch
+++ b/ports/ms-quic/fix-uwp-crt.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3f8f4d58f..df689627c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -598,9 +598,9 @@ if(WIN32)
+     endif()
+ 
+     if (NOT QUIC_STATIC_LINK_CRT AND NOT QUIC_STATIC_LINK_PARTIAL_CRT)
+-        # We are using dynamic linking. Ensure that only the release version of CRT is used.
+-        message(STATUS "Configuring for release version of dynamically linked CRT")
+-        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
++        # We are using dynamic linking. Ensure that only the dynamic CRT is used.
++        message(STATUS "Configuring for dynamically linked CRT")
++        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+     endif()
+ 
+ else() #!WIN32

--- a/ports/ms-quic/portfile.cmake
+++ b/ports/ms-quic/portfile.cmake
@@ -7,8 +7,14 @@ vcpkg_from_github(
     SHA512 5937fbc2f287567d590fc0afc947459359e5413fa25f2f193434ad6d7016f7cb0dede4e2ef5e1e4e8b21b556c5ad8ce4cb612514403bb593a49af0fb42d1cb15
     HEAD_REF master
     PATCHES
-        fix-install.patch   # Adjust install path of build outputs
+        fix-install.patch # Adjust install path of build outputs
+        fix-uwp-crt.patch # https://github.com/microsoft/msquic/pull/4373
+        fix-comparing-system-processor-with-win32.patch # https://github.com/microsoft/msquic/pull/4374
 )
+
+# This avoids a link error on x86-windows:
+# LINK : fatal error LNK1268: inconsistent option 'NODEFAULTLIB:libucrt.lib' specified with /USEPROFILE but not with /GENPROFILE
+file(REMOVE "${QUIC_SOURCE_PATH}/src/bin/winuser/pgo_x86/msquic.pgd")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH OPENSSL_SOURCE_PATH
@@ -17,32 +23,35 @@ vcpkg_from_github(
     SHA512 ff487d882c2b70ed8915a88ecf0a64724435a96187a7bb3bf401f4a2c4dc572a93f7e788040ccbd29da8bc6ac49ee11550c9d56153262c05fae173ac1d242baa
     HEAD_REF openssl-3.1.5+quic
 )
-file(REMOVE_RECURSE ${QUIC_SOURCE_PATH}/submodules/openssl)
-file(RENAME ${OPENSSL_SOURCE_PATH} ${QUIC_SOURCE_PATH}/submodules/openssl)
+
+file(REMOVE_RECURSE "${QUIC_SOURCE_PATH}/submodules/openssl")
+file(RENAME "${OPENSSL_SOURCE_PATH}" "${QUIC_SOURCE_PATH}/submodules/openssl")
+
 vcpkg_from_github(
     OUT_SOURCE_PATH XDP_WINDOWS
     REPO microsoft/xdp-for-windows
     REF ce228a986fd30049ed58f569d2bf20efffc250f3
     SHA512 4a26c5defe422ef42308d72cf8d1cab1c172ce5a10d8d830c446cb7dd93f0c41f35f3cbbfeceb687d5135272006dd1b1bc4c2089ace4866cede81d5c76206af7
-    HEAD_REF mian
+    HEAD_REF main
 )
-file(REMOVE_RECURSE ${QUIC_SOURCE_PATH}/submodules/xdp-for-windows)
-file(RENAME ${XDP_WINDOWS} ${QUIC_SOURCE_PATH}/submodules/xdp-for-windows)
+
+file(REMOVE_RECURSE "${QUIC_SOURCE_PATH}/submodules/xdp-for-windows")
+file(RENAME "${XDP_WINDOWS}" "${QUIC_SOURCE_PATH}/submodules/xdp-for-windows")
 
 vcpkg_find_acquire_program(PERL)
-get_filename_component(PERL_EXE_PATH ${PERL} DIRECTORY)
-vcpkg_add_to_path(${PERL_EXE_PATH})
+get_filename_component(PERL_EXE_PATH "${PERL}" DIRECTORY)
+vcpkg_add_to_path("${PERL_EXE_PATH}")
 
 if(NOT VCPKG_HOST_IS_WINDOWS)
     find_program(MAKE make)
-    get_filename_component(MAKE_EXE_PATH ${MAKE} DIRECTORY)
-    vcpkg_add_to_path(PREPEND ${MAKE_EXE_PATH})
+    get_filename_component(MAKE_EXE_PATH "${MAKE}" DIRECTORY)
+    vcpkg_add_to_path(PREPEND "${MAKE_EXE_PATH}")
 endif()
 
  if(VCPKG_TARGET_IS_WINDOWS)
      vcpkg_find_acquire_program(NASM)
-     get_filename_component(NASM_EXE_PATH ${NASM} DIRECTORY)
-     vcpkg_add_to_path(PREPEND ${NASM_EXE_PATH})
+     get_filename_component(NASM_EXE_PATH "${NASM}" DIRECTORY)
+     vcpkg_add_to_path(PREPEND "${NASM_EXE_PATH}")
  endif()
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -53,23 +62,22 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" STATIC_CRT)
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${QUIC_SOURCE_PATH}
+    SOURCE_PATH "${QUIC_SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
         -DQUIC_SOURCE_LINK=OFF
         -DQUIC_TLS=openssl
-        -DQUIC_TLS_SECRETS_SUPPORT=ON
         -DQUIC_USE_SYSTEM_LIBCRYPTO=OFF
         -DQUIC_BUILD_PERF=OFF
         -DQUIC_BUILD_TEST=OFF
-        -DQUIC_STATIC_LINK_CRT=${STATIC_CRT}
-        -DQUIC_UWP_BUILD=${VCPKG_TARGET_IS_UWP}
+        "-DQUIC_STATIC_LINK_CRT=${STATIC_CRT}"
+        "-DQUIC_UWP_BUILD=${VCPKG_TARGET_IS_UWP}"
 )
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-if("tools" IN_LIST FEATURES)
+if("tools" IN_LIST "FEATURES")
     vcpkg_copy_tools(TOOL_NAMES quicattack quicinterop quicinteropserver quicipclient quicipserver
                                 quicpcp quicpost quicsample spinquic
         AUTO_CLEAN
@@ -77,6 +85,6 @@ if("tools" IN_LIST FEATURES)
 endif()
 
 vcpkg_install_copyright(FILE_LIST "${QUIC_SOURCE_PATH}/LICENSE")
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share
-                    ${CURRENT_PACKAGES_DIR}/debug/include
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include"
 )

--- a/ports/ms-quic/vcpkg.json
+++ b/ports/ms-quic/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ms-quic",
   "version": "2.3.5",
+  "port-version": 1,
   "description": "Cross-platform, C implementation of the IETF QUIC protocol",
   "homepage": "https://github.com/microsoft/msquic",
   "license": "MIT",
@@ -17,7 +18,8 @@
   ],
   "features": {
     "tools": {
-      "description": "Install the tools after build"
+      "description": "Install the tools after build",
+      "supports": "!uwp"
     }
   }
 }

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -758,19 +758,13 @@ mozjpeg:arm-neon-android=fail
 mozjpeg:arm64-android=fail
 mozjpeg:x64-android=fail
 mpir:x64-android=fail
-# ms-gltf and ms-quic require the Microsoft GDK with Xbox Extensions which is not installed on the CI pipeline machines
+# ms-gltf require the Microsoft GDK with Xbox Extensions which is not installed on the CI pipeline machines
 ms-gdkx:x64-windows=fail
 ms-gdkx:x64-windows-static=fail
 ms-gdkx:x64-windows-static-md=fail
 ms-gltf:arm-neon-android=fail
 ms-gltf:arm64-android=fail
 ms-gltf:x64-android=fail
-ms-quic:arm64-uwp=fail
-ms-quic:arm64-windows=fail
-ms-quic:x64-uwp=fail
-ms-quic:x64-windows-static-md=fail
-ms-quic:x64-windows=fail
-ms-quic:x86-windows=fail
 monkeys-audio:arm64-windows=fail
 monkeys-audio:x64-windows-static=fail
 moos-core:x64-windows-static=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5958,7 +5958,7 @@
     },
     "ms-quic": {
       "baseline": "2.3.5",
-      "port-version": 0
+      "port-version": 1
     },
     "msdfgen": {
       "baseline": "1.12",

--- a/versions/m-/ms-quic.json
+++ b/versions/m-/ms-quic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a43543429fb53d28aabfdccfefe70a93744d8971",
+      "version": "2.3.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "5b057833638702cb3bbdb72a8cb131cce473c46e",
       "version": "2.3.5",
       "port-version": 0


### PR DESCRIPTION
Also fix uwp builds so that all ci.baseline.txt entries can be removed, submitted upstream as https://github.com/microsoft/msquic/pull/4373 Also fix x86-windows builds which incorrectly compared SYSTEM_PROCESSOR with 'win32' rather than 'x86'. Submitted upstream as https://github.com/microsoft/msquic/pull/4374 . This patch originally authored by @LillyWangLL

Originally started from https://github.com/microsoft/vcpkg/pull/39475

Co-authored by: Lily Wang <v-lilywang@microsoft.com>
